### PR TITLE
m.youtube.com ではプレイヤーのコントローラーを監視して表示/非表示を切り替える

### DIFF
--- a/src/js/modules/Config.js
+++ b/src/js/modules/Config.js
@@ -169,11 +169,15 @@ Config.ui.m_youtube_com = {
   /** @param {Function} callback 監視対象が変更されたとき呼ばれる関数。引数trueならフェードイン、それ以外フェードアウト。 */
   observe(callback) {
     const target = document.querySelector("#player-control-overlay");
-    if (target == null) return null;
+    if (target == null) {
+      callback(null);
+      return;
+    }
 
+    // NOTE: 停止時やタップしたとき.fadeinが存在する
+    const hasFadein = () => target.classList.contains("fadein");
     const observer = new MutationObserver(() => {
-      // NOTE: 停止時やタップしたとき.fadeinが存在する
-      callback(target.classList.contains("fadein"));
+      callback(hasFadein());
     });
 
     observer.observe(target, {
@@ -181,7 +185,7 @@ Config.ui.m_youtube_com = {
       attributeFilter: ["class"]
     });
 
-    return observer;
+    callback(hasFadein());
   },
   target: "#player-control-container",
   style: `#${Config.ui.id} {

--- a/src/js/modules/UI/index.js
+++ b/src/js/modules/UI/index.js
@@ -53,5 +53,15 @@ export default class UI {
     this.element.attachShadow({ mode: "open" });
     this.status.attach(this.element.shadowRoot);
     target.appendChild(this.element);
+
+    // プレイヤーのコントローラーを監視して表示/非表示を切り替える
+    const ovserve = Config.get_ui_observer();
+    if (ovserve != null) {
+      this.element.classList.add("fadein");
+      ovserve((fadein) /* 引数を.fadeinの有無として反映 */ => {
+        if (fadein) this.element.classList.add("fadein");
+        else this.element.classList.remove("fadein");
+      });
+    }
   }
 }

--- a/src/js/modules/UI/index.js
+++ b/src/js/modules/UI/index.js
@@ -57,7 +57,6 @@ export default class UI {
     // プレイヤーのコントローラーを監視して表示/非表示を切り替える
     const ovserve = Config.get_ui_observer();
     if (ovserve != null) {
-      this.element.classList.add("fadein");
       ovserve((fadein) /* 引数を.fadeinの有無として反映 */ => {
         if (fadein) this.element.classList.add("fadein");
         else this.element.classList.remove("fadein");


### PR DESCRIPTION
#player-control-container > ytm-custom-control > #player-control-overlay の要素の .fadein と :not(.fadein) の変更をJSで監視して見た目を変更する実装にしました。

#player-control-overlay の属性以外に単純な表示・非表示状態の取得方法を見つけることができず、
また #player-control-container > ytm-custom-control 要素は利用者の再生・一時停止など操作によって更新されるため子や兄弟として追加するのが難しく、加えて疑似セレクター :has を実装しているブラウザーが存在しないため利用出来ず、結果CSSだけでは実装困難と判断しMutationObserverを用いた実装にしました。
ほかに素敵な実装方法がもしあれば教えて下さい :bowing_man: